### PR TITLE
创建 Release 自动构建

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -56,12 +56,12 @@ jobs:
       - name: ls
         run: ls -lrt
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: my-artifact
-          path: |
-            *.qpkg
-            *.md5
+      # - uses: actions/upload-artifact@v3
+      #   with:
+      #     name: my-artifact
+      #     path: |
+      #       *.qpkg
+      #       *.md5
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -5,10 +5,12 @@ name: CI
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  # push:
+  #   branches: ["main"]
+  # pull_request:
+  #   branches: ["main"]
+  release:
+    types: [published]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/AList/qpkg.cfg
+++ b/AList/qpkg.cfg
@@ -1,6 +1,6 @@
 QPKG_NAME="alist"
 QPKG_DISPLAY_NAME="多云盘挂载"
-QPKG_VER="3.12.2"
+QPKG_VER="3.14.0"
 QPKG_AUTHOR="bbis<br><span class=font-bold>简介：</span>支持多种网络存储、挂载本地存储、阿里云盘、OneDrive、Google Drive 等,支持网页浏览和 WebDAV<br><span class=font-bold>开源：</span>https://github.com/iranee/qnap-alist-webdav"
 QPKG_SUMMARY="A file list tools."
 QPKG_RC_NUM="501"

--- a/AList/qpkg.cfg
+++ b/AList/qpkg.cfg
@@ -1,6 +1,6 @@
 QPKG_NAME="alist"
 QPKG_DISPLAY_NAME="多云盘挂载"
-QPKG_VER="3.11.0"
+QPKG_VER="3.12.0"
 QPKG_AUTHOR="bbis<br><span class=font-bold>简介：</span>支持多种网络存储、挂载本地存储、阿里云盘、OneDrive、Google Drive 等,支持网页浏览和 WebDAV<br><span class=font-bold>开源：</span>https://github.com/iranee/qnap-alist-webdav"
 QPKG_SUMMARY="A file list tools."
 QPKG_RC_NUM="501"

--- a/AList/qpkg.cfg
+++ b/AList/qpkg.cfg
@@ -1,6 +1,6 @@
 QPKG_NAME="alist"
 QPKG_DISPLAY_NAME="多云盘挂载"
-QPKG_VER="3.12.0"
+QPKG_VER="3.12.2"
 QPKG_AUTHOR="bbis<br><span class=font-bold>简介：</span>支持多种网络存储、挂载本地存储、阿里云盘、OneDrive、Google Drive 等,支持网页浏览和 WebDAV<br><span class=font-bold>开源：</span>https://github.com/iranee/qnap-alist-webdav"
 QPKG_SUMMARY="A file list tools."
 QPKG_RC_NUM="501"


### PR DESCRIPTION
softprops/action-gh-release 是可以直接用的，trigger 改成 release: published 比较合适

更改完 qpkg.cfg 之后发一个新的 release 就会自动构建并上传了，可以去掉 upload-artifact 的部分

谢谢大哥更改的项目，孩子很喜欢，丰衣足食，已经构建了两个版本了 ❤
